### PR TITLE
update proxy-wasm-go-sdk to 0.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/kauche/proxy-wasm-google-metadata-identity-token
 
 go 1.20
 
-require github.com/tetratelabs/proxy-wasm-go-sdk v0.20.0
+require github.com/tetratelabs/proxy-wasm-go-sdk v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-github.com/tetratelabs/proxy-wasm-go-sdk v0.20.0 h1:i/xtxt/jHXtp/yImhlp4pAWx0eVzIBKOaay3Nu4Iw3k=
-github.com/tetratelabs/proxy-wasm-go-sdk v0.20.0/go.mod h1:7uUubjgZpmccNAPqSS6Il6CF+tk3BGf4qSCJZp3W8s8=
+github.com/tetratelabs/proxy-wasm-go-sdk v0.22.0 h1:kS7BvMKN+FiptV4pfwiNX8e3q14evxAWkhYbxt8EI1M=
+github.com/tetratelabs/proxy-wasm-go-sdk v0.22.0/go.mod h1:qkW5MBz2jch2u8bS59wws65WC+Gtx3x0aPUX5JL7CXI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
- update proxy-wasm-go-sdk to 0.22.0